### PR TITLE
enabling whitenoise package to keep the Swagger UI even in production

### DIFF
--- a/homelessAPI/bin/docker-entrypoint.sh
+++ b/homelessAPI/bin/docker-entrypoint.sh
@@ -2,5 +2,5 @@
 export PATH=$PATH:~/.local/bin
 #./bin/getconfig.sh
 #python manage.py migrate --noinput
-#python manage.py collectstatic --noinput
+python manage.py collectstatic --noinput
 gunicorn homelessAPI.wsgi:application -b :8000 --worker-class 'gevent' --workers 1

--- a/homelessAPI/homelessAPI/settings.py
+++ b/homelessAPI/homelessAPI/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'rest_framework',
     'rest_framework_swagger',
@@ -58,6 +59,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -147,6 +149,8 @@ USE_TZ = True
 STATIC_URL = "/homeless/static/"
 STATIC_ROOT = 'staticfiles'
 #STATIC_ROOT = BASE_DIR + '/homelessApp/static/'
+
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # # testing setup
 # TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/homelessAPI/homelessAPI/wsgi.py
+++ b/homelessAPI/homelessAPI/wsgi.py
@@ -14,6 +14,12 @@ from gevent import monkey; monkey.patch_all()
 
 patch_psycopg()
 
+from whitenoise.django import DjangoWhiteNoise
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "homelessAPI.settings")
 
 application = get_wsgi_application()
+
+# WhiteNoise allows us to serve the Swagger static files directly from Django even when settings.py:DEBUG=False
+# This saves us the trouble of having to build a static files web server, though that would be a great long-term solution
+application = DjangoWhiteNoise(application)

--- a/homelessAPI/requirements.txt
+++ b/homelessAPI/requirements.txt
@@ -20,3 +20,4 @@ uritemplate==3.0.0
 gunicorn
 gevent==1.2.1
 psycogreen
+whitenoise==3.3.0


### PR DESCRIPTION
This allows the Django app to be able to serve the Swagger static files even when we set DEBUG=False for production usage.  If we didn't add this package to the app, then as soon as you switch DEBUG from True to False, the Swagger UI disappears and the http://service.civicpdx.org/homeless pages look ugly as sin again.